### PR TITLE
fix: enforce strict metrics reporting guidelines

### DIFF
--- a/integration/src/mastra/agents/metricsResponseAgent.ts
+++ b/integration/src/mastra/agents/metricsResponseAgent.ts
@@ -17,11 +17,13 @@ You operate in two modes:
 
 IN METRICS MODE:
 - You have access to metrics data like CPU usage, load averages, memory statistics
-- Analyze metrics and offer insights about server health
+- ONLY analyze and discuss metrics that are explicitly provided in the data
+- NEVER make up, guess, or hallucinate metric values that aren't shown
+- If a metric isn't in the data, don't mention or discuss it
 - For high resource usage (above 80%), suggest potential issues and remediation steps
 - For critical usage (above 90%), flag urgently and provide recommendations
 - Interpret metrics in a friendly, conversational way
-- Provide valuable insights beyond just raw numbers
+- Provide valuable insights based ONLY on the metrics actually present
 
 IN CONVERSATION MODE:
 - Answer general questions about server monitoring concepts
@@ -29,13 +31,15 @@ IN CONVERSATION MODE:
 - Explain what metrics are available if the user seems unfamiliar
 - If users ask for specific metrics you don't have data for, inform them you'll fetch that information
 - Keep responses helpful and focused on server monitoring topics
+- NEVER make up or guess at metric values even if asked directly
 
 GENERAL GUIDELINES:
 - Be concise but informative
 - Only reference previous conversation context if it's clear and explicit
-- Don't fabricate metrics data when you don't have it
+- NEVER fabricate metrics data when you don't have it
+- If asked about a metric that isn't provided, explain that you don't have that data
 - Adapt your tone based on context: friendly for casual conversation, more urgent for critical metrics
-- When providing metric values, always include the units (%, GB, etc.)
+- When providing metric values, always include the units (%, GB, etc.) and only use values explicitly shown in the data
 
 TEXT FORMATTING:
 - DO NOT use asterisks (*) for any text formatting or emphasis

--- a/integration/src/services/zeromqServer.ts
+++ b/integration/src/services/zeromqServer.ts
@@ -143,16 +143,18 @@ User asked: ${message.data.userMessage}
 Current server metrics:
 ${formattedMetrics}
 
+IMPORTANT: Only report and discuss the exact metrics shown above. Never make up or hallucinate metrics that aren't explicitly provided.
 Based on the above metrics and the user's question, provide a helpful, conversational response. 
-Analyze the metrics and provide insights. If values are high (above 80%), include suggestions.`
+Analyze only the metrics that are actually present in the data. If values are high (above 80%), include suggestions.`
                     : `
 User asked: ${message.data.userMessage}
 
 Current server metrics:
 ${formattedMetrics}
 
+IMPORTANT: Only report and discuss the exact metrics shown above. Never make up or hallucinate metrics that aren't explicitly provided.
 Based on the above metrics and the user's question, provide a helpful, conversational response.
-Analyze the metrics and provide insights. If values are high (above 80%), include suggestions.`;
+Analyze only the metrics that are actually present in the data. If values are high (above 80%), include suggestions.`;
 
                   // Generate enhanced response
                   const enhancedResponse = await metricsResponseAgent.generate(


### PR DESCRIPTION
- Updated metricsResponseAgent to only analyze and discuss metrics explicitly provided in the data.
- Added clear instructions to avoid fabricating or guessing metric values that are not present.
- Enhanced zeromqServer to ensure responses are based solely on the metrics shown, reinforcing the importance of accurate reporting.
- Improved overall clarity in the handling of metrics data to maintain integrity in responses.