### PR TITLE
feat: update metrics agent to use new model version

### DIFF
--- a/integration/src/mastra/agents/metricsAgent.ts
+++ b/integration/src/mastra/agents/metricsAgent.ts
@@ -4,7 +4,8 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 const google = createGoogleGenerativeAI({
   apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
 });
-const model = google("gemini-2.0-flash-exp");
+// const model = google("gemini-2.0-flash-exp");
+const model = google("gemini-2.0-flash-001");
 
 export const metricsAiAgent = new Agent({
   name: "Server Monitor Classifier",

--- a/integration/src/mastra/agents/metricsResponseAgent.ts
+++ b/integration/src/mastra/agents/metricsResponseAgent.ts
@@ -4,7 +4,8 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 const google = createGoogleGenerativeAI({
   apiKey: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
 });
-const model = google("gemini-2.0-flash-exp");
+// const model = google("gemini-2.0-flash-exp");
+const model = google("gemini-2.0-flash-001");
 
 export const metricsResponseAgent = new Agent({
   name: "Metrics Response Agent",


### PR DESCRIPTION
- Replaced the deprecated model "gemini-2.0-flash-exp" with "gemini-2.0-flash-001" in both metricsAgent.ts and metricsResponseAgent.ts.
- Commented out the old model for reference.